### PR TITLE
feat(pubsub): prefetch property added in order one worker to acknowladge single message then process another

### DIFF
--- a/packages/rabbitmq-pubsub/src/common.ts
+++ b/packages/rabbitmq-pubsub/src/common.ts
@@ -1,4 +1,15 @@
 export interface IQueueNameConfig {
+  /**
+   *  Set the prefetch count for this channel.
+   *  The count given is the maximum number of messages
+   *  sent over the channel that can be awaiting acknowledgement
+   *  once there are count messages outstanding,
+   *  the server will not send more messages on this channel
+   *  until one or more have been acknowledged.
+   *  A falsey value for count indicates no such limit.
+   *  https://www.squaremobius.net/amqp.node/channel_api.html#channel_prefetch
+   */
+  prefetch?: number;
   name: string;
   dlq: string;
   dlx: string;

--- a/packages/rabbitmq-pubsub/src/publisher.ts
+++ b/packages/rabbitmq-pubsub/src/publisher.ts
@@ -61,7 +61,7 @@ export class RabbitMqPublisher {
 
   protected getSettings(): amqp.Options.AssertQueue {
     return {
-      durable: false,
+      durable: true,
       autoDelete: true,
     };
   }


### PR DESCRIPTION
# Description
This pull request will help us to say how much messages can this consumer take.

## Type of change

- [x] Non Breaking change

## Checklist

- [x] Sets channels to durable in order to preserve state of the messages after broker crash
- [x] Prefetch option introduced when `graphql-pubsub-subscriptions` package is subscribing 

```ts
import { Controller, PubSubService } from '@gapi/core';

@Controller()
export class IotController {
  constructor(private pubsub: PubSubService) {
    pubsub.subscribe('relay', (data) => {}, { prefetch: 1 });
  }
}

```
